### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,10 @@
 [![Build Status](https://travis-ci.org/ckan/ckanapi-exporter.svg)](https://travis-ci.org/ckan/ckanapi-exporter)
 [![Coverage Status](https://img.shields.io/coveralls/ckan/ckanapi-exporter.svg)](https://coveralls.io/r/ckan/ckanapi-exporter)
-[![Latest Version](https://pypip.in/version/ckanapi-exporter/badge.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
-[![Downloads](https://pypip.in/download/ckanapi-exporter/badge.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
-[![Supported Python versions](https://pypip.in/py_versions/ckanapi-exporter/badge.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
-[![Development Status](https://pypip.in/status/ckanapi-exporter/badge.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
-[![License](https://pypip.in/license/ckanapi-exporter/badge.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
+[![Latest Version](https://img.shields.io/pypi/v/ckanapi-exporter.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
+[![Downloads](https://img.shields.io/pypi/dm/ckanapi-exporter.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/ckanapi-exporter.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
+[![Development Status](https://img.shields.io/pypi/status/ckanapi-exporter.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
+[![License](https://img.shields.io/pypi/l/ckanapi-exporter.svg)](https://pypi.python.org/pypi/ckanapi-exporter/)
 
 ckanapi-exporter
 ================


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ckanapi-exporter))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ckanapi-exporter`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.